### PR TITLE
Suggestions

### DIFF
--- a/REVIEW.md
+++ b/REVIEW.md
@@ -11,3 +11,4 @@ This module uses a ".ignore" file that lists files to not sync. It reads that fi
 *Provide a list of 5+ aspects of the code that should be improved. Each suggestion for improvement should be accompanied by a GitHub pull request on the reviewee's submission repo that shows how to perform the suggested refactoring. If the change is so substantial that it is "rewriting" the solution, break it down into a series of refactorings that build on each other to improve the solution (each refactoring committed separately and submitted as a pull request with a thorough explanation).*
 
 1. Printing the files that are being synced every second clutters the console log.
+2. Change the for-in to a regular for loop. The for-in should be used to iterate through properties of an object, not through elements of an array.

--- a/REVIEW.md
+++ b/REVIEW.md
@@ -13,3 +13,4 @@ This module uses a ".ignore" file that lists files to not sync. It reads that fi
 1. Printing the files that are being synced every second can get overwhelming for the user.
 2. Change the for-in to a regular for loop in the ignoreFiles method in ignore.js. The for-in should be used to iterate through properties of an object, not through elements of an array.
 3. Ignoring files wasn't working (at least for Windows) because there were extra non-ASCII characters at the end of each file name in the .ignore file. I performed a .trim() on each element in the filesToIgnore array in the ignoreFiles method in ignore.js.
+4. Changed the ignoreFiles method to use a callback instead of return a value.

--- a/REVIEW.md
+++ b/REVIEW.md
@@ -14,3 +14,4 @@ This module uses a ".ignore" file that lists files to not sync. It reads that fi
 2. Change the for-in to a regular for loop in the ignoreFiles method in ignore.js. The for-in should be used to iterate through properties of an object, not through elements of an array.
 3. Ignoring files wasn't working (at least for Windows) because there were extra non-ASCII characters at the end of each file name in the .ignore file. I performed a .trim() on each element in the filesToIgnore array in the ignoreFiles method in ignore.js.
 4. Changed the ignoreFiles method to use a callback instead of return a value.
+5. Separate the getting the list of files to ignore to its own method.

--- a/REVIEW.md
+++ b/REVIEW.md
@@ -1,0 +1,13 @@
+# Review of \<firstname\> \<lastname\> by \<your\_first\_name\> \<your\_last\_name\> 
+
+## Overview
+
+*Provide a 1-3 paragraph overview of the architecture of the code and the design rationale.*
+
+This module uses a ".ignore" file that lists files to not sync. It reads that file and removes the listed files from the given file list.
+
+## Suggested Improvements
+
+*Provide a list of 5+ aspects of the code that should be improved. Each suggestion for improvement should be accompanied by a GitHub pull request on the reviewee's submission repo that shows how to perform the suggested refactoring. If the change is so substantial that it is "rewriting" the solution, break it down into a series of refactorings that build on each other to improve the solution (each refactoring committed separately and submitted as a pull request with a thorough explanation).*
+
+1. Printing the files that are being synced every second clutters the console log.

--- a/REVIEW.md
+++ b/REVIEW.md
@@ -10,5 +10,6 @@ This module uses a ".ignore" file that lists files to not sync. It reads that fi
 
 *Provide a list of 5+ aspects of the code that should be improved. Each suggestion for improvement should be accompanied by a GitHub pull request on the reviewee's submission repo that shows how to perform the suggested refactoring. If the change is so substantial that it is "rewriting" the solution, break it down into a series of refactorings that build on each other to improve the solution (each refactoring committed separately and submitted as a pull request with a thorough explanation).*
 
-1. Printing the files that are being synced every second clutters the console log.
-2. Change the for-in to a regular for loop. The for-in should be used to iterate through properties of an object, not through elements of an array.
+1. Printing the files that are being synced every second can get overwhelming for the user.
+2. Change the for-in to a regular for loop in the ignoreFiles method in ignore.js. The for-in should be used to iterate through properties of an object, not through elements of an array.
+3. Ignoring files wasn't working (at least for Windows) because there were extra non-ASCII characters at the end of each file name in the .ignore file. I performed a .trim() on each element in the filesToIgnore array in the ignoreFiles method in ignore.js.

--- a/lib/sync/ignore.js
+++ b/lib/sync/ignore.js
@@ -11,7 +11,7 @@ function ignoreFiles(path, files){
 	var data = fs.readFileSync(ignoreFilePath, "utf-8");
 	var filesToIgnore = data.split("\n");
 	var newList = [];
-	for(var i in files){
+	for(var index = 0; i < files.length; ++index){
 		var file = files[i];
 		if(filesToIgnore.indexOf(file) == -1){
 			newList.push(file);

--- a/lib/sync/ignore.js
+++ b/lib/sync/ignore.js
@@ -10,8 +10,11 @@ function ignoreFiles(path, files){
 	var ignoreFilePath = uris.getPath(path) + "/" + ignoreFile;
 	var data = fs.readFileSync(ignoreFilePath, "utf-8");
 	var filesToIgnore = data.split("\n");
+	for(var i = 0; i < filesToIgnore.length; ++i) {
+		filesToIgnore[i] = filesToIgnore[i].trim();
+	}
 	var newList = [];
-	for(var index = 0; i < files.length; ++index){
+	for(var i = 0; i < files.length; ++i){
 		var file = files[i];
 		if(filesToIgnore.indexOf(file) == -1){
 			newList.push(file);

--- a/lib/sync/ignore.js
+++ b/lib/sync/ignore.js
@@ -8,19 +8,25 @@ var uris = require("./dropboxuris");
 function ignoreFiles(path, files, cb){
 	var ignoreFile = ".ignore";
 	var ignoreFilePath = uris.getPath(path) + "/" + ignoreFile;
+	listFilesToIgnore(ignoreFilePath, function(filesToIgnore) {
+		var newList = [];
+		for(var i = 0; i < files.length; ++i){
+			var file = files[i];
+			if(filesToIgnore.indexOf(file) == -1){
+				newList.push(file);
+			}
+		}
+		cb(newList);
+	});
+}
+
+function listFilesToIgnore(ignoreFilePath, cb) {
 	var data = fs.readFileSync(ignoreFilePath, "utf-8");
 	var filesToIgnore = data.split("\n");
 	for(var i = 0; i < filesToIgnore.length; ++i) {
 		filesToIgnore[i] = filesToIgnore[i].trim();
 	}
-	var newList = [];
-	for(var i = 0; i < files.length; ++i){
-		var file = files[i];
-		if(filesToIgnore.indexOf(file) == -1){
-			newList.push(file);
-		}
-	}
-	cb(newList);
+	cb(filesToIgnore);
 }
 
 module.exports = {

--- a/lib/sync/ignore.js
+++ b/lib/sync/ignore.js
@@ -5,7 +5,7 @@ var uris = require("./dropboxuris");
   Check the file names in .ignore
   For the file names in .ignore, do not sync
 */
-function ignoreFiles(path, files){
+function ignoreFiles(path, files, cb){
 	var ignoreFile = ".ignore";
 	var ignoreFilePath = uris.getPath(path) + "/" + ignoreFile;
 	var data = fs.readFileSync(ignoreFilePath, "utf-8");
@@ -20,7 +20,7 @@ function ignoreFiles(path, files){
 			newList.push(file);
 		}
 	}
-	return newList;
+	cb(newList);
 }
 
 module.exports = {

--- a/lib/sync/ignore.js
+++ b/lib/sync/ignore.js
@@ -17,7 +17,6 @@ function ignoreFiles(path, files){
 			newList.push(file);
 		}
 	}
-	console.log("Files to sync: " + newList);
 	return newList;
 }
 

--- a/lib/sync/sync-client.js
+++ b/lib/sync/sync-client.js
@@ -8,7 +8,7 @@ function connect(options,onConnect) {
     var port = options.port || 5004;
     var host = options.host || "127.0.0.1";
 
-    var d = dnode();
+    var d = dnode({},{weak:false});
     var conn = d.connect(host,port);
     var server = null;
 

--- a/lib/sync/sync-server.js
+++ b/lib/sync/sync-server.js
@@ -43,7 +43,7 @@ var server = dnode({
     readFile: function(path,cb){
         cb(base64util.readBase64Encoded(base + path));
     }
-});
+},{weak:false});
 
 server.listen(argv.port);
 

--- a/lib/sync/sync-server.js
+++ b/lib/sync/sync-server.js
@@ -29,7 +29,9 @@ var server = dnode({
     list: function(path,cb){
         path = base + path;
         var rslt = fs.readdirSync(path);
-        cb(ign.ignoreFiles(path, rslt));
+        ign.ignoreFiles(path, rslt, function(fileList) {
+            cb(fileList);
+        });
     },
     stat: function(path,cb){
         path = base + path;

--- a/lib/sync/sync.js
+++ b/lib/sync/sync.js
@@ -7,7 +7,9 @@ var ign = require("./ignore");
 var localFs = {
     list:function(path,cb){
         path = uris.getPath(path);
-        cb(ign.ignoreFiles(path,fs.readdirSync(path)));
+        ign.ignoreFiles(path,fs.readdirSync(path),function(fileList) {
+            cb(fileList);
+        });
     },
     stat:function(path,cb){
         path = uris.getPath(path);


### PR DESCRIPTION
1. Printing the files that are being synced every second can get overwhelming for the user.
2. Change the for-in to a regular for loop in the ignoreFiles method in ignore.js. The for-in should be used to iterate through properties of an object, not through elements of an array.
3. Ignoring files wasn't working (at least for Windows) because there were extra non-ASCII characters at the end of each file name in the .ignore file. I performed a .trim() on each element in the filesToIgnore array in the ignoreFiles method in ignore.js.
4. Changed the ignoreFiles method to use a callback instead of return a value.
5. Separate the getting the list of files to ignore to its own method.